### PR TITLE
feat(version): Add version via setuptools_scm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,7 @@ setup(
     package_dir={},
     package_data={},
     include_package_data=True,
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
     install_requires=["pywebvue"],
 )

--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -3,6 +3,8 @@ import inspect
 
 from pywebvue import App
 
+from .version import __version__
+
 NEXT_TRIGGER_ID = 0
 TRIGGER_MAP = {}
 NEXT_APP_ID = 0

--- a/trame/version.py
+++ b/trame/version.py
@@ -1,0 +1,8 @@
+# When we require python 3.8, we can use importlib.metadata instead...
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    __version__ = get_distribution("trame").version
+except DistributionNotFound:
+    # package is not installed
+    __version__ = None


### PR DESCRIPTION
`setuptools_scm` automatically generates a version based upon the latest git tag.

This commit also adds code to get the version at runtime. For instance:
```python
>>> import trame
>>> trame.__version__
'1.2.4.dev18+gf6594a0.d20211028'
```

Since I'm in a dev environment, there are dev details added to the version.