### PR TITLE
feat(state): add class for pythonic state access

### DIFF
--- a/examples/VTK/Applications/VTPViewer/app.py
+++ b/examples/VTK/Applications/VTPViewer/app.py
@@ -1,4 +1,4 @@
-import trame as tr
+from trame import change, state
 from trame.layouts import SinglePage
 from trame.html import vtk, vuetify, StateChange
 
@@ -10,7 +10,7 @@ from vtkmodules.web.utils import mesh as vtk_mesh
 # -----------------------------------------------------------------------------
 
 
-@tr.change("files")
+@change("files")
 def load_client_files(files, **kwargs):
     field = "solid"
     fields = {
@@ -68,10 +68,10 @@ def load_client_files(files, **kwargs):
                 vtk_mesh(ds, point_arrays=point_arrays, cell_arrays=cell_arrays)
             )
 
-    tr.update_state("field", field)
-    tr.update_state("fields", fields)
-    tr.update_state("meshes", meshes)
-    tr.update_state("files", filesOutput)
+    state.field = field
+    state.fields = fields
+    state.meshes = meshes
+    state.files = filesOutput
     print(f"show {len(meshes)} meshes")
 
 
@@ -79,8 +79,8 @@ def load_client_files(files, **kwargs):
 # Web App setup
 # -----------------------------------------------------------------------------
 
-tr.update_state("fields", [])
-tr.update_state("meshes", [])
+state.fields = []
+state.meshes = []
 
 layout = SinglePage("File loading")
 layout.title.set_text("File Loader")

--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -3,7 +3,7 @@ from trame.dev import main
 from trame.layouts import update_layout
 from trame.server import port, start, stop
 from trame.state import (
-    change, flush_state, get_state, is_dirty, is_dirty_all, update_state
+    change, flush_state, get_state, is_dirty, is_dirty_all, State, update_state
 )
 from trame.trigger import trigger, trigger_key
 from trame.utils import (
@@ -13,11 +13,17 @@ from trame.utils import (
 
 __version__ = get_version()
 
+# Create an instance of the static State class so it may be
+# accessed via `from trame import state`
+state = State()
+
 __all__ = [
     # Order these how we want them to show up in the docs
     "start",
     "stop",
     "port",
+    "State",
+    "state",
     "update_state",
     "get_state",
     "update_layout",

--- a/trame/state/__init__.py
+++ b/trame/state/__init__.py
@@ -1,5 +1,7 @@
 from .decorators import change
-from .state import flush_state, get_state, is_dirty, is_dirty_all, update_state
+from .core import (
+    flush_state, get_state, is_dirty, is_dirty_all, State, update_state
+)
 
 __all__ = [
     "change",
@@ -7,5 +9,6 @@ __all__ = [
     "get_state",
     "is_dirty",
     "is_dirty_all",
+    "State",
     "update_state",
 ]

--- a/trame/state/core.py
+++ b/trame/state/core.py
@@ -129,3 +129,34 @@ def is_dirty_all(*args):
     """
     _app = get_app_instance()
     return _app.is_dirty_all(*args)
+
+
+class State:
+    """This static class provides pythonic access to the state
+
+    For instance, these getters are the same:
+
+    >>> field, = get_state("field")
+    >>> field = state.field
+
+    As are these setters:
+
+    >>> update_state("field", value)
+    >>> state.field = value
+
+    ``get_state()`` should be used instead if more than one argument is to be
+    passed, and ``update_state()`` should be used instead to specify additional
+    arguments (e.g. ``force=True``).
+
+    An instance of this static class can be imported via
+
+    >>> from trame import state
+    """
+    @staticmethod
+    def __getattr__(name):
+        value, = get_state(name)
+        return value
+
+    @staticmethod
+    def __setattr__(name, value):
+        update_state(name, value)


### PR DESCRIPTION
This allows for state access like this:
```python
from trame import state

state.field = value
result = state.field
```

As opposed to:
```python
from trame import get_state, update_state

update_state("field", value)
result, = get_state("field")
```

However, `update_state()` should still be used when extra arguments are needed (e.g., `force=True`), and `get_state()` can still be used for passing in multiple names.

The VTPViewer was modified to demonstrate this change.