### PR TITLE
feat(Controller): add Controller class for function proxies

### DIFF
--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -13,16 +13,33 @@ from trame.utils import (
 
 __version__ = get_version()
 
-# Create an instance of the static State class so it may be
-# accessed via `from trame import state`
 state = State()
+"""This object provides pythonic access to the state
+
+For instance, these getters are the same:
+
+>>> field, = get_state("field")
+>>> field = state.field
+
+As are these setters:
+
+>>> update_state("field", value)
+>>> state.field = value
+
+``get_state()`` should be used instead if more than one argument is to be
+passed, and ``update_state()`` should be used instead to specify additional
+arguments (e.g. ``force=True``).
+
+This object may be imported via
+
+>>> from trame import state
+"""
 
 __all__ = [
     # Order these how we want them to show up in the docs
     "start",
     "stop",
     "port",
-    "State",
     "state",
     "update_state",
     "get_state",

--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -5,7 +5,7 @@ from trame.server import port, start, stop
 from trame.state import (
     change, flush_state, get_state, is_dirty, is_dirty_all, State, update_state
 )
-from trame.trigger import trigger, trigger_key
+from trame.trigger import Controller, trigger, trigger_key
 from trame.utils import (
     get_cli_parser, get_version, log_js_error, print_server_info,
     validate_key_names
@@ -35,6 +35,25 @@ This object may be imported via
 >>> from trame import state
 """
 
+controller = Controller()
+"""The controller is a container for function proxies
+
+The function proxies may be used as callbacks even though the function has
+not yet been defined. The function may also be re-defined. For example:
+
+>>> from trame import controller as ctrl
+>>> layout = SinglePage("Controller test")
+>>> with layout.toolbar:
+...     vuetify.VSpacer()
+...     vuetify.VBtn("Click Me", click=ctrl.on_click)  # not yet defined
+
+>>> ctrl.on_click = lambda: print("Hello, Trame!")  # on_click is now defined
+
+This can be very useful for large projects where the functions may be defined
+in separate files after the UI has been constructed, or for re-defining
+callbacks when conditions in the application change.
+"""
+
 __all__ = [
     # Order these how we want them to show up in the docs
     "start",
@@ -50,6 +69,7 @@ __all__ = [
     "is_dirty_all",
     "change",
     "trigger",
+    "controller",
 
     # These are not exposed in the docs
     "__version__",

--- a/trame/state/core.py
+++ b/trame/state/core.py
@@ -154,6 +154,10 @@ class State:
     """
     @staticmethod
     def __getattr__(name):
+        if name[:2] == name[-2:] == "__":
+            # Forward dunder calls to object
+            return getattr(object, name)
+
         value, = get_state(name)
         return value
 

--- a/trame/state/core.py
+++ b/trame/state/core.py
@@ -1,4 +1,5 @@
 from trame import get_app_instance
+from trame.utils import is_dunder
 
 
 def update_state(key, value=None, force=False):
@@ -154,7 +155,7 @@ class State:
     """
     @staticmethod
     def __getattr__(name):
-        if name[:2] == name[-2:] == "__":
+        if is_dunder(name):
             # Forward dunder calls to object
             return getattr(object, name)
 

--- a/trame/trigger/__init__.py
+++ b/trame/trigger/__init__.py
@@ -1,7 +1,9 @@
+from .controller import Controller
 from .core import trigger_key
 from .decorators import trigger
 
 __all__ = [
+    "Controller",
     "trigger",
     "trigger_key",
 ]

--- a/trame/trigger/controller.py
+++ b/trame/trigger/controller.py
@@ -1,0 +1,63 @@
+from trame.utils import is_dunder
+
+
+class Controller:
+    """Controller acts as a container for function proxies
+
+    It allows functions to be passed around that are not yet defined,
+    and can be defined or re-defined later. For example:
+
+    >>> f = ctrl.hello_func  # function is currently undefined
+    >>> ctrl.hello_func = lambda: print("Hello, world!")
+    >>> f()
+    Hello, world!
+
+    >>> ctrl.hello_func = lambda: print("Hello again!")
+    >>> f()
+    Hello again!
+    """
+    def __init__(self):
+        super().__setattr__('_func_dict', {})
+
+    def __getattr__(self, name):
+        if is_dunder(name):
+            return super().__getattr__(name)
+
+        if name not in self._func_dict:
+            self._func_dict[name] = ControllerFunction(name)
+
+        # The ControllerFunction object is callable, but we will return the
+        # __call__ method for greater compatibility in case a function is
+        # required.
+        return self._func_dict[name].__call__
+
+    def __setattr__(self, name, func):
+        if name in self._func_dict:
+            self._func_dict[name].func = func
+        else:
+            self._func_dict[name] = ControllerFunction(name, func)
+
+
+class ControllerFunction:
+    """Controller functions are callable function proxy objects
+
+    Any calls are forwarded to the internal function, which may be
+    undefined or dynamically changed. If a call is made when the
+    internal function is undefined, a FunctionNotImplementedError is
+    raised.
+    """
+    def __init__(self, name, func=None):
+        # The name is needed to provide more helpful information upon
+        # a FunctionNotImplementedError exception.
+        self.name = name
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        if self.func is None:
+            raise FunctionNotImplementedError(self.name)
+
+        return self.func(*args, **kwargs)
+
+
+class FunctionNotImplementedError(Exception):
+    pass

--- a/trame/utils/__init__.py
+++ b/trame/utils/__init__.py
@@ -3,6 +3,7 @@ from .cli import get_cli_parser
 from .compose import compose_callbacks
 from .filesystem import base_directory
 from .logging import log_js_error, print_server_info, validate_key_names
+from .string import is_dunder
 from .version import get_version
 
 
@@ -13,6 +14,7 @@ __all__ = [
     "compose_callbacks",
     "get_cli_parser",
     "get_version",
+    "is_dunder",
     "log_js_error",
     "print_server_info",
     "validate_key_names",

--- a/trame/utils/string.py
+++ b/trame/utils/string.py
@@ -1,0 +1,3 @@
+def is_dunder(s):
+    # Check if this is a double underscore (dunder) name
+    return len(s) > 4 and s.isascii() and s[:2] == s[-2:] == "__"


### PR DESCRIPTION
This class allows function proxies to be used for callbacks, where the underlying function may be
temporarily undefined or the definition may change in the future. An object of the Controller
class may be imported via `from trame import controller as ctrl`.