### PR TITLE
Add State __setitem__, __getitem__, and update()

### DIFF
--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -30,6 +30,12 @@ As are these setters:
 passed, and ``update_state()`` should be used instead to specify additional
 arguments (e.g. ``force=True``).
 
+The state may also be accessed and updated similar to dictionaries:
+
+>>> value = state["field"]
+>>> state["field"] = value
+>>> state.update({"field": value})
+
 This object may be imported via
 
 >>> from trame import state

--- a/trame/state/core.py
+++ b/trame/state/core.py
@@ -165,3 +165,11 @@ class State:
     @staticmethod
     def __setattr__(name, value):
         update_state(name, value)
+
+    @staticmethod
+    def __getitem__(name):
+        return State.__getattr__(name)
+
+    @staticmethod
+    def __setitem__(name, value):
+        State.__setattr__(name, value)

--- a/trame/state/core.py
+++ b/trame/state/core.py
@@ -149,6 +149,12 @@ class State:
     passed, and ``update_state()`` should be used instead to specify additional
     arguments (e.g. ``force=True``).
 
+    The state may also be accessed and updated similar to dictionaries:
+
+    >>> value = state["field"]
+    >>> state["field"] = value
+    >>> state.update({"field": value})
+
     An instance of this static class can be imported via
 
     >>> from trame import state
@@ -164,6 +170,15 @@ class State:
 
     @staticmethod
     def __setattr__(name, value):
+        # Do not allow pre-existing attributes, such as update(), to be
+        # re-defined.
+        if name in State.__dict__:
+            msg = (
+                f"'{name}' is a special attribute on State that cannot be "
+                "re-assigned"
+            )
+            raise Exception(msg)
+
         update_state(name, value)
 
     @staticmethod
@@ -173,3 +188,7 @@ class State:
     @staticmethod
     def __setitem__(name, value):
         State.__setattr__(name, value)
+
+    @staticmethod
+    def update(d):
+        return update_state(d)


### PR DESCRIPTION
feat(State): add `__setitem__` and `__getitem__`
    
This allows state attributes to be accessed with brackets, such as `field = state["field"]`, or
`state["field"] = field`.

feat(State): add update() method
    
This method functions similar to the update() method of dictionaries, in that it is passed a
dictionary, and each key is assigned to it's corresponding value in the state.