### PR TITLE
feat(setup_dev): add setup_dev() function for reloading trame applications

### DIFF
--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -1,6 +1,7 @@
 from trame.internal import (
   change, Controller, flush_state, get_cli_parser, get_state, get_version,
-  is_dirty, is_dirty_all, port, start, State, stop, trigger, update_state
+  is_dirty, is_dirty_all, port, setup_dev, start, State, stop, trigger,
+  update_state
 )
 from trame.layouts import update_layout
 
@@ -79,6 +80,9 @@ __all__ = [
 
     # CLI-related
     "get_cli_parser",
+
+    # Dev-related
+    "setup_dev",
 
     # These are not exposed in the docs
     "__version__",

--- a/trame/internal/__init__.py
+++ b/trame/internal/__init__.py
@@ -1,5 +1,5 @@
 from .app import activate_app, create_app, deactivate_app, get_app_instance
-from .dev import main
+from .dev import main, setup_dev
 from .server import port, start, stop
 from .state import (
     change, flush_state, get_state, is_dirty, is_dirty_all, State, update_state

--- a/trame/internal/app/app.py
+++ b/trame/internal/app/app.py
@@ -83,9 +83,16 @@ def create_app(name):
 
     # Default app initialization
     _app.trigger("js_error")(log_js_error)
-    _app.cli_parser.add_argument(
+
+    parser = _app.cli_parser
+    parser.add_argument(
         "--server",
         help="Prevent your browser from opening at startup",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--dev",
+        help="Allow dynamically reloading the server",
         action="store_true",
     )
 

--- a/trame/internal/dev/__init__.py
+++ b/trame/internal/dev/__init__.py
@@ -1,5 +1,6 @@
-from .dev import main
+from .dev import main, setup_dev
 
 __all__ = [
     "main",
+    "setup_dev",
 ]

--- a/trame/internal/dev/dev.py
+++ b/trame/internal/dev/dev.py
@@ -16,40 +16,94 @@ def main():
     This functionality is in Alpha but we aim to improve it based on
     needs and feedback from the community.
     """
+    import importlib
+
     from trame.internal.app import get_app_instance
-    from trame.internal.utils import log_js_error
 
     _app = get_app_instance()
     parser = _app.cli_parser
     parser.add_argument("script", help="The script to run")
-    parser.add_argument(
-        "--dev", help="Allow to dynamically reload server", action="store_true"
-    )
     args, _unknown = parser.parse_known_args()
-
-    import importlib.util
 
     spec = importlib.util.spec_from_file_location("app", args.script)
     app = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(app)
 
+    setup_dev(app, clear_changes=True)
+
+    app.layout.start()
+
+
+def setup_dev(*reload_list, clear_changes=False, clear_triggers=True):
+    """
+    Set up a development environment for the trame app if --dev was passed
+    as a command line argument. If enabled, a reload button will appear at the
+    bottom of the web browser which will reload the modules that were passed as
+    arguments.
+
+    :param reload_list: positional arguments of the modules to reload when the
+                        reload button is pressed.
+    :type reload_list: python modules
+    :param clear_changes: whether or not to clear changes on reload
+    :type clear_changes: bool
+    :param clear_triggers: whether or not to clear triggers on reload
+    :type clear_triggers: bool
+    :rtype: bool
+    :returns: whether the program is running in dev mode or not
+    """
+    from trame.internal.app import get_app_instance
+
+    _app = get_app_instance()
+    parser = _app.cli_parser
+    args, _unknown = parser.parse_known_args()
+
+    if not args.dev:
+        # We are not running in development mode
+        return False
+
     # Register reload trigger
     def reload():
         print("\nReloading application...")
-        _app._change_callbacks.clear()
-        _app._triggers.clear()
+
+        if clear_changes:
+            _app._change_callbacks.clear()
+
+        if clear_triggers:
+            # Never clear these triggers
+            trigger_whitelist = [
+                "js_error",
+                "server_reload",
+            ]
+            _remove_keys(_app._triggers, trigger_whitelist)
+
         _app.reload_app()
 
-        # Keep sys trame ones
-        _app._triggers["server_reload"] = reload
-        _app._triggers["js_error"] = log_js_error
+        def reload_modules(*modules):
+            for m in modules:
+                m.__loader__.exec_module(m)
 
-        spec = importlib.util.spec_from_file_location("app", args.script)
-        app = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(app)
-        app.layout.flush_content()
+                if hasattr(m, 'on_reload'):
+                    m.on_reload(reload_modules)
+
+        for module in reload_list:
+            reload_modules(module)
+
+            if hasattr(module, 'layout'):
+                module.layout.flush_content()
+
         print(" > done !\n")
 
+    # Set the reload trigger
     _app.trigger("server_reload")(reload)
 
-    app.layout.start(debug=args.dev)
+    return True
+
+
+def _remove_keys(d, whitelist=None):
+    # Remove all keys from a dict except for those in the whitelist
+    if whitelist is None:
+        whitelist = []
+
+    pop_keys = [k for k in d if k not in whitelist]
+    for key in pop_keys:
+        d.pop(key)

--- a/trame/internal/triggers/core.py
+++ b/trame/internal/triggers/core.py
@@ -19,15 +19,15 @@ def trigger_key(_fn):
     """
     # Return precomputed key
     global TRIGGER_MAP, NEXT_TRIGGER_ID
-    if _fn in TRIGGER_MAP:
-        return TRIGGER_MAP[_fn]
+    if _fn not in TRIGGER_MAP:
+        # Compute unique trigger key
+        NEXT_TRIGGER_ID += 1
+        TRIGGER_MAP[_fn] = f"trigger_{NEXT_TRIGGER_ID}"
 
-    # Compute unique trigger key
-    NEXT_TRIGGER_ID += 1
-    key = f"trigger_{NEXT_TRIGGER_ID}"
-    TRIGGER_MAP[_fn] = key
+    key = TRIGGER_MAP[_fn]
 
     # Register function trigger
+    # This happens every time in case a reload occurred
     _app = tri.get_app_instance()
     _app.trigger(key)(_fn)
 

--- a/trame/layouts/core.py
+++ b/trame/layouts/core.py
@@ -80,15 +80,24 @@ class AbstractLayout:
         _app = tri.get_app_instance()
         _app.layout = self.html
 
-    def start(self, port=None, debug=False):
+    def start(self, port=None, debug=None):
         """
         Start the application server.
 
         :param port: Which port to run the server on
-        :param debug: Whether to enable debugging tools. Defaults to False.
-        :type debug: bool
+        :param debug: Whether to enable debugging tools. Defaults to
+                      None, in which case it is set to True if the --dev
+                      flag was passed as a command line argument.
+        :type debug: bool or None
         """
         _app = tri.get_app_instance()
+
+        if debug is None:
+            parser = _app.cli_parser
+            args, _unknown = parser.parse_known_args()
+            debug = args.dev
+
+        _app._debug = debug
 
         _app.name = self.name
         _app.layout = self.html


### PR DESCRIPTION
This function takes modules to reload when the reload button is pressed, which is visible if the 
`--dev` argument is passed. This appears to be working both for running
`trame --dev <single_file>`, and by calling the `setup_dev()` function in a custom trame
application, along with passing the `--dev` flag to the python command. The function will
additionally call an `on_reload` function in any module it finds, and pass it another function that
can be used to reload more modules.