### PR TITLE
Add conda docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,15 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+
+    # Start a local registry to which we will push trame-common, so that
+    # docker buildx may access it in later steps.
+    services:
+      registry:
+        image: registry
+        ports:
+          - 5000:5000
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,6 +30,8 @@ jobs:
       # For multi-platform builds
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
 
       - name: Create month stamp
         run: echo "MONTH_STAMP=$(date +%Y-%m)" >> $GITHUB_ENV
@@ -31,24 +42,58 @@ jobs:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Build and push
+      - name: Build common
+        uses: docker/build-push-action@v2
+        with:
+            platforms: linux/amd64,linux/arm64
+            context: docker
+            file: docker/Dockerfile.common
+            push: true
+            tags: localhost:5000/trame-common
+
+      - name: Build common (glvnd)
         uses: docker/build-push-action@v2
         with:
             context: docker
+            file: docker/Dockerfile.common
+            build-args: BASE_IMAGE=nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
+            push: true
+            tags: localhost:5000/trame-common-glvnd
+
+      - name: Build and push (pip)
+        uses: docker/build-push-action@v2
+        with:
             platforms: linux/amd64,linux/arm64
+            context: docker
+            file: docker/Dockerfile.pip
+            build-args: BASE_IMAGE=localhost:5000/trame-common
             push: true
             tags: |
                 kitware/trame:latest
                 kitware/trame:ubuntu-20.04-py39
                 kitware/trame:${{ env.MONTH_STAMP }}
 
-      - name: Build and push (glvnd)
+      - name: Build and push (pip glvnd)
         uses: docker/build-push-action@v2
         with:
             context: docker
+            file: docker/Dockerfile.pip
+            build-args: BASE_IMAGE=localhost:5000/trame-common-glvnd
             push: true
-            build-args: BASE_IMAGE=nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
             tags: |
                 kitware/trame:glvnd
                 kitware/trame:1.2-glvnd-runtime-ubuntu20.04-py39
                 kitware/trame:glvnd_${{ env.MONTH_STAMP }}
+
+      - name: Build and push (conda)
+        uses: docker/build-push-action@v2
+        with:
+            platforms: linux/amd64,linux/arm64
+            context: docker
+            file: docker/Dockerfile.conda
+            build-args: BASE_IMAGE=localhost:5000/trame-common
+            push: true
+            tags: |
+                kitware/trame:conda
+                kitware/trame:conda_ubuntu-20.04-py39
+                kitware/trame:conda_${{ env.MONTH_STAMP }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,3 +41,14 @@ jobs:
                 kitware/trame:latest
                 kitware/trame:ubuntu-20.04-py39
                 kitware/trame:${{ env.MONTH_STAMP }}
+
+      - name: Build and push (glvnd)
+        uses: docker/build-push-action@v2
+        with:
+            context: docker
+            push: true
+            build-args: BASE_IMAGE=nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
+            tags: |
+                kitware/trame:glvnd
+                kitware/trame:1.2-glvnd-runtime-ubuntu20.04-py39
+                kitware/trame:glvnd_${{ env.MONTH_STAMP }}

--- a/docker/Dockerfile.common
+++ b/docker/Dockerfile.common
@@ -6,37 +6,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y \
-      python3.9 \
-      # python3.9-distutils is required to install pip
-      # it unfortunately has to install python3.8-minimal as well...
-      python3.9-distutils \
-      # python-is-python3 creates a symlink for python to python3
-      python-is-python3 \
-      # For creating virtual environments
-      python3.9-venv \
-      # wget is used to obtain pip
       wget \
-      # apache
       apache2 \
       apache2-dev \
       libapr1-dev \
       apache2-utils \
       gosu && \
     rm -rf /var/lib/apt/lists/*
-
-# Set python3 to python3.9 (otherwise, it will be python3.8)
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
-
-# Never use a cache directory for pip, both here in this Dockerfile
-# and when we run the container.
-ENV PIP_NO_CACHE_DIR=1
-
-# Install and upgrade pip
-RUN wget -O- https://bootstrap.pypa.io/get-pip.py | python3.9 && \
-    pip install -U pip
-
-# Install setup dependencies
-RUN pip install PyYAML
 
 # Set up needed permissions and users
 RUN groupadd trame-user -g 1000 && \
@@ -45,24 +21,17 @@ RUN groupadd trame-user -g 1000 && \
     usermod -a -G proxy-mapping www-data && \
     mkdir -p /opt/trame && \
     chown -R trame-user:trame-user /opt/trame && \
+    mkdir -p /home/trame-user && \
+    chown -R trame-user:trame-user /home/trame-user && \
     touch /opt/trame/proxy-mapping.txt && \
     chown trame-user:proxy-mapping /opt/trame/proxy-mapping.txt && \
-    chmod 660 /opt/trame/proxy-mapping.txt
+    chmod 660 /opt/trame/proxy-mapping.txt && \
+    mkdir -p /deploy && \
+    chown -R trame-user:trame-user /deploy
 
 # Copy the apache configuration file into place
 COPY config/apache/001-trame.conf /etc/apache2/sites-available/001-trame.conf
 COPY config/default-launcher.json /opt/trame/default-launcher.json
-
-# Copy the scripts into place
-COPY scripts/entrypoint.sh \
-     scripts/fix_uid_gid.sh \
-     scripts/generate_launcher_config.py \
-     scripts/generate_www.py \
-     scripts/make_directories.sh \
-     scripts/server.sh \
-     scripts/start.sh \
-     scripts/yaml_to_json.py \
-     /opt/trame/
 
 # Configure the apache web server
 RUN a2enmod vhost_alias && \
@@ -75,10 +44,10 @@ RUN a2enmod vhost_alias && \
     a2ensite 001-trame && \
     a2dismod autoindex -f
 
+# Copy the scripts into place
+COPY scripts/* /opt/trame/
+
 # Open port 80 to the world outside the container
 EXPOSE 80
-
-ENV PV_VENV=/deploy/server/venv
-ENV VTK_VENV=$PV_ENV
 
 ENTRYPOINT ["/opt/trame/entrypoint.sh"]

--- a/docker/Dockerfile.conda
+++ b/docker/Dockerfile.conda
@@ -1,0 +1,26 @@
+ARG BASE_IMAGE=trame-common
+FROM ${BASE_IMAGE}
+
+# Install miniconda
+ENV CONDA_DIR /opt/conda
+RUN if [ $(uname -m) = "x86_64" ]; then arch="x86_64"; else arch="aarch64"; fi && \
+    wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$arch.sh -O /miniconda.sh && \
+    /bin/bash /miniconda.sh -b -p $CONDA_DIR && \
+    rm /miniconda.sh && \
+    chown -R trame-user:trame-user $CONDA_DIR
+
+# Put conda in the path
+ENV PATH=$CONDA_DIR/bin:$PATH
+
+# Install pyyaml
+RUN gosu trame-user conda install -y --freeze-installed -c conda-forge \
+      pyyaml && \
+    conda clean -afy
+
+# Copy the scripts into place
+COPY scripts/conda/* /opt/trame/
+
+# Set venv paths
+ENV TRAME_VENV=/deploy/server/venv
+ENV PV_VENV=$TRAME_VENV
+ENV VTK_VENV=$TRAME_VENV

--- a/docker/Dockerfile.pip
+++ b/docker/Dockerfile.pip
@@ -1,0 +1,36 @@
+ARG BASE_IMAGE=trame-common
+FROM ${BASE_IMAGE}
+
+RUN apt-get update && \
+    apt-get install -y \
+      python3.9 \
+      # python3.9-distutils is required to install pip
+      # it unfortunately has to install python3.8-minimal as well...
+      python3.9-distutils \
+      # python-is-python3 creates a symlink for python to python3
+      python-is-python3 \
+      # For creating virtual environments
+      python3.9-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set python3 to python3.9 (otherwise, it will be python3.8)
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+
+# Never use a cache directory for pip, both here in this Dockerfile
+# and when we run the container.
+ENV PIP_NO_CACHE_DIR=1
+
+# Install and upgrade pip
+RUN wget -q -O- https://bootstrap.pypa.io/get-pip.py | python3.9 && \
+    pip install -U pip
+
+# Install setup dependencies
+RUN pip install PyYAML
+
+# Copy the pip scripts into place
+COPY scripts/pip/* /opt/trame/
+
+# Set venv paths
+ENV TRAME_VENV=/deploy/server/venv
+ENV PV_VENV=$TRAME_VENV
+ENV VTK_VENV=$TRAME_VENV

--- a/docker/scripts/conda/activate_venv.sh
+++ b/docker/scripts/conda/activate_venv.sh
@@ -1,0 +1,3 @@
+# Ensure we are in the base conda environment first, or it won't work.
+. $CONDA_DIR/bin/activate
+conda activate $TRAME_VENV

--- a/docker/scripts/conda/create_venv.sh
+++ b/docker/scripts/conda/create_venv.sh
@@ -1,0 +1,6 @@
+# Ensure we are in the base conda environment first, or it won't work.
+. $CONDA_DIR/bin/activate
+
+conda create -y conda python=3.9 --prefix $TRAME_VENV
+conda activate $TRAME_VENV
+conda clean -afy

--- a/docker/scripts/conda/install_requirements.sh
+++ b/docker/scripts/conda/install_requirements.sh
@@ -1,0 +1,5 @@
+# Install requirements (if it exists)
+if [ -f /deploy/setup/requirements.txt ]
+then
+  conda install -y --file /deploy/setup/requirements.txt
+fi

--- a/docker/scripts/entrypoint.sh
+++ b/docker/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ ! -d /deploy ]
+if [ ! -d /deploy/server ] && [ ! -d /deploy/setup ]
 then
   echo "ERROR: The deploy directory must be mounted into the container at /deploy"
   exit 1

--- a/docker/scripts/fix_uid_gid.sh
+++ b/docker/scripts/fix_uid_gid.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
-deploy_uid=$(stat -c '%u' /deploy)
-deploy_gid=$(stat -c '%g' /deploy)
+check_dir=/deploy/server
+if [ ! -d $check_dir ]
+then
+  check_dir=/deploy/setup
+fi
+
+deploy_uid=$(stat -c '%u' $check_dir)
+deploy_gid=$(stat -c '%g' $check_dir)
 
 trame_user_uid=$(id -u trame-user)
 trame_user_gid=$(id -g trame-user)

--- a/docker/scripts/pip/activate_venv.sh
+++ b/docker/scripts/pip/activate_venv.sh
@@ -1,0 +1,1 @@
+. $TRAME_VENV/bin/activate

--- a/docker/scripts/pip/create_venv.sh
+++ b/docker/scripts/pip/create_venv.sh
@@ -1,0 +1,5 @@
+python -m venv $TRAME_VENV
+. $TRAME_VENV/bin/activate
+
+# Update pip
+pip install -U pip

--- a/docker/scripts/pip/install_requirements.sh
+++ b/docker/scripts/pip/install_requirements.sh
@@ -1,0 +1,5 @@
+# Install requirements (if it exists)
+if [ -f /deploy/setup/requirements.txt ]
+then
+  pip install -r /deploy/setup/requirements.txt
+fi

--- a/docker/scripts/server.sh
+++ b/docker/scripts/server.sh
@@ -1,19 +1,13 @@
 #!/usr/bin/env bash
 
-venv_dir=/deploy/server/venv
-
-if [ ! -d $venv_dir ]
+if [ ! -d $TRAME_VENV ]
 then
   # We have access to PyYAML in the root python environment.
   # Convert the apps.yml file to json and put it in the right place.
   python /opt/trame/yaml_to_json.py /deploy/setup/apps.yml /opt/trame/apps.json
 
-  # Create and install the virtual environment
-  python -m venv $venv_dir
-  . $venv_dir/bin/activate
-
-  # Upgrade pip
-  pip install -U pip
+  # Create (and activate) the venv
+  . /opt/trame/create_venv.sh
 
   # Run the initialize script (if it exists)
   if [ -f /deploy/setup/initialize.sh ]
@@ -21,11 +15,8 @@ then
     . /deploy/setup/initialize.sh
   fi
 
-  # Install requirements (if it exists)
-  if [ -f /deploy/setup/requirements.txt ]
-  then
-    pip install -r /deploy/setup/requirements.txt
-  fi
+  # Install any specified requirements
+  . /opt/trame/install_requirements.sh
 
   # Generate launcher.json and the www directory
   python /opt/trame/generate_launcher_config.py
@@ -37,7 +28,7 @@ then
     cp -r /deploy/setup/www/* /deploy/server/www
   fi
 else
-  . $venv_dir/bin/activate
+  . /opt/trame/activate_venv.sh
 fi
 
 if [[ $TRAME_BUILD_ONLY == 1 ]]; then


### PR DESCRIPTION
This places common Dockerfile code in `Dockerfile.common`, and adds a `Dockerfile.pip` and
`Dockerfile.conda` which are based off of it. It also adds scripts unique to conda and pip in
`conda` and `pip` subdirectories, which get copied via their respective Dockerfiles.

This also adds conda and glvnd builds to CI. 