### PR TITLE
chore(docker): use glvnd devel instead of runtime

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
         with:
             context: docker
             file: docker/Dockerfile.common
-            build-args: BASE_IMAGE=nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
+            build-args: BASE_IMAGE=nvidia/opengl:1.2-glvnd-devel-ubuntu20.04
             push: true
             tags: localhost:5000/trame-common-glvnd
 


### PR DESCRIPTION
Apparently, glvnd devel is required to run ParaView, since it includes libOpenGL, but the runtime
does not.
