### PR TITLE
feat(layout): add kwargs to AbstractLayout.start()

### DIFF
--- a/trame/layouts/core.py
+++ b/trame/layouts/core.py
@@ -99,7 +99,7 @@ class AbstractLayout:
             if isinstance(template, AbstractElement):
                 route["component"]["template"] = template.html
 
-    def start(self, port=None, debug=None):
+    def start(self, port=None, debug=None, **kwargs):
         """
         Start the application server.
 
@@ -108,6 +108,13 @@ class AbstractLayout:
                       None, in which case it is set to True if the --dev
                       flag was passed as a command line argument.
         :type debug: bool or None
+        :param kwargs: arguments to forward to run_server()
+
+        Some of the kwargs that may be forwarded to run_server() include:
+
+            * exec_mode (str): "main" (default) or "task" for running in an
+                               environment that already has an event loop,
+                               such as a Jupyter notebook.
         """
         _app = tri.get_app_instance()
 
@@ -128,7 +135,7 @@ class AbstractLayout:
         # Dev validation
         tri.validate_key_names()
 
-        _app.run_server(port=port)
+        _app.run_server(port=port, **kwargs)
 
     def start_thread(
         self, port=None, print_server_info=False, on_server_listening=None, **kwargs

--- a/trame/layouts/core.py
+++ b/trame/layouts/core.py
@@ -112,7 +112,7 @@ class AbstractLayout:
         _app = tri.get_app_instance()
 
         self._init_app(_app)
-  
+
         if debug is None:
             parser = _app.cli_parser
             args, _unknown = parser.parse_known_args()
@@ -134,7 +134,7 @@ class AbstractLayout:
         self, port=None, print_server_info=False, on_server_listening=None, **kwargs
     ):
         _app = tri.get_app_instance()
-        
+
         self._init_app(_app)
 
         if print_server_info:
@@ -156,7 +156,7 @@ class AbstractLayout:
         _msg_queue = Queue()
 
         _app = tri.get_app_instance()
-        
+
         self._init_app(_app)
 
         async def process_msg():


### PR DESCRIPTION
These kwargs get forwarded to `App.run_server()`. An example of `exec_mode` is provided in the documentation.
