### PR TITLE
feat(jupyter): add utility functions for running in jupyter

### DIFF
--- a/trame/internal/utils/logging.py
+++ b/trame/internal/utils/logging.py
@@ -5,7 +5,7 @@ def log_js_error(message):
     print(f" > JS error | {message}")
 
 
-def print_server_info(_fn=None):
+def print_server_info(_fn=None, server=None, **kwargs):
     """Provide network info so clients can connect to the started server"""
     from trame.internal.app import get_app_instance
 
@@ -40,7 +40,11 @@ def print_server_info(_fn=None):
             except TypeError:
                 _fn()
 
-        if not args.server:
+        nonlocal server
+        if server is None:
+            server = args.server
+
+        if not server:
             import webbrowser
             import asyncio
 

--- a/trame/jupyter/__init__.py
+++ b/trame/jupyter/__init__.py
@@ -1,0 +1,7 @@
+from .display import display_iframe
+from .proxy import run
+
+__all__ = [
+    "display_iframe",
+    "run",
+]

--- a/trame/jupyter/display.py
+++ b/trame/jupyter/display.py
@@ -1,0 +1,15 @@
+from IPython import display
+
+
+def display_iframe(src, **kwargs):
+    """Convenience method to display an iframe for the given url source"""
+
+    # Set some defaults. The kwargs can override these.
+    # width and height are both required.
+    iframe_kwargs = {
+        "width": "100%",
+        "height": 600,
+        **kwargs,
+    }
+    iframe = display.IFrame(src=src, **iframe_kwargs)
+    return display.display(iframe)

--- a/trame/jupyter/proxy.py
+++ b/trame/jupyter/proxy.py
@@ -1,0 +1,12 @@
+from .display import display_iframe
+
+
+def run(name, **kwargs):
+    """Run and display a Jupyter server proxy process with the given name
+
+    Note that the proxy process must be registered with Jupyter by setting
+    the `jupyter_serverproxy_servers` entrypoint in its setup.py or setup.cfg
+    file.
+    """
+    src = f"/{name}"
+    return display_iframe(src, **kwargs)

--- a/trame/layouts/core.py
+++ b/trame/layouts/core.py
@@ -115,6 +115,10 @@ class AbstractLayout:
             * exec_mode (str): "main" (default) or "task" for running in an
                                environment that already has an event loop,
                                such as a Jupyter notebook.
+
+        The kwargs will also be forwarded to print_server_info(), so that
+        the `server` kwarg may be used to indicate whether a new window
+        should be opened.
         """
         _app = tri.get_app_instance()
 
@@ -126,11 +130,7 @@ class AbstractLayout:
             debug = args.dev
 
         _app._debug = debug
-
-        if self.on_ready:
-            _app.on_ready = tri.print_server_info(self.on_ready)
-        else:
-            _app.on_ready = tri.print_server_info()
+        _app.on_ready = tri.print_server_info(self.on_ready, **kwargs)
 
         # Dev validation
         tri.validate_key_names()


### PR DESCRIPTION
The utility functions can be helpful both for running trame in the jupyter event loop and for running trame as a separate jupyter server proxy process. Cookie cutter examples are soon to follow.
