### PR TITLE
Pywebview fixes

### DIFF
--- a/examples/VTK/SimpleCone/RemoteRendering.py
+++ b/examples/VTK/SimpleCone/RemoteRendering.py
@@ -1,3 +1,5 @@
+import multiprocessing
+
 from trame import state
 from trame.html import vuetify, vtk
 from trame.layouts import SinglePage
@@ -24,6 +26,7 @@ DEFAULT_RESOLUTION = 6
 renderer = vtkRenderer()
 renderWindow = vtkRenderWindow()
 renderWindow.AddRenderer(renderer)
+renderWindow.OffScreenRenderingOn()
 
 renderWindowInteractor = vtkRenderWindowInteractor()
 renderWindowInteractor.SetRenderWindow(renderWindow)
@@ -92,4 +95,9 @@ with layout.content:
 # -----------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    # Freeze support is needed particularly for Windows, to prevent infinite
+    # recursion when multiprocessing is used.
+    multiprocessing.freeze_support()
     layout.start()
+    # The layout can alternatively be started as a desktop window instead
+    # layout.start_desktop_window()


### PR DESCRIPTION
fix(pywebview): support newer versions and windows
    
Newer versions of pywebvue set the closing events on `window.events.closing` instead of on
`window.closing`. And Windows appears to freeze up if we call `window.destroy()`. In my testing,
it appears that both Windows and Linux close cleanly without `window.destroy()`, so it was removed.

fix(RemoteRendering.py): hide render window and support multiprocessing on Windows
    
This hides the extra render window that appears, and adds support for multiprocessing on Windows,
where `freeze_support()` is required to prevent infinite recursion when starting the program in
other processes. This also shows that `layout.start_desktop_window()` may be used instead.