### PR TITLE
Implement v-on and v-bind

### DIFF
--- a/examples/PlainPython/Menu/README.md
+++ b/examples/PlainPython/Menu/README.md
@@ -1,0 +1,20 @@
+# Menu example
+
+This example illustrates how to implement a dropdown menu in vuetify using `v-slot:activator` with `v-bind` and `v-on` like this one:
+
+```html
+<template>
+  <v-menu>
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn v-bind="attrs" v-on="on"> Dropdown </v-btn>
+    </template>
+    <v-list>
+      <v-list-item v-for="(item, index) in items" :key="index">
+        <v-list-item-title>{{ item.title }}</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>
+```
+
+And demonstrate how to pass variables from Vue to a Python method.

--- a/examples/PlainPython/Menu/app.py
+++ b/examples/PlainPython/Menu/app.py
@@ -1,0 +1,31 @@
+from trame import state
+from trame.html import vuetify
+from trame.layouts import SinglePage
+
+layout = SinglePage("Menu example")
+
+state.menu_items = ["one", "two", "three"]
+
+
+def print_item(item):
+    print("Clicked on", item)
+
+
+with layout.toolbar:
+    vuetify.VSpacer()
+    with vuetify.VMenu():
+        with vuetify.Template(v_slot_activator="{ on, attrs }"):
+            with vuetify.VBtn(icon=True, v_bind="attrs", v_on="on", v_on_click="test"):
+                vuetify.VIcon("mdi-dots-vertical")
+        with vuetify.VList(), vuetify.VListItem(
+            v_for="(item, i) in menu_items",
+            key="i",
+            value=["item"],
+        ):
+            vuetify.VBtn(
+                "{{ item }}",
+                click=(print_item, "[item]"),
+            )
+
+if __name__ == "__main__":
+    layout.start()


### PR DESCRIPTION
v-on and v-bind were not mapped from python keys to vue keys, which made it not possible to implement and example like this:

```python
with vuetify.VMenu():
    with vuetify.Template(v_slot_activator="{ on, attrs }"):
        with vuetify.VBtn(icon=True, v_bind="attrs", v_on="on", v_on_click="test"):
            vuetify.VIcon("mdi-dots-vertical")
    with vuetify.VList(), vuetify.VListItem(
        v_for="(item, i) in menu_items",
        key="i",
        value=["item"],
    ):
        vuetify.VBtn(
            "{{ item }}",
            click=(print_item, "[item]"),
        )
```

Note: The list of `v_on_names` does not cover all possibilities yet. Since you can chain most of the keywords in different ways, we should probably build the list programmatically. (e.g. `v-on:click.self.stop.prevent` etc.)