### PR TITLE
Ensure javascript files get the correct mimetype

### DIFF
--- a/trame/app/__init__.py
+++ b/trame/app/__init__.py
@@ -2,6 +2,9 @@ from trame_server import Server
 from trame_client import module
 from trame_client.widgets.core import VirtualNode
 
+# Ensure this is imported so that mimetypes.init() is decorated
+import trame.app.mimetypes  # noqa: F401
+
 DEFAULT_NAME = "trame"
 AVAILABLE_SERVERS = {}
 

--- a/trame/app/mimetypes.py
+++ b/trame/app/mimetypes.py
@@ -1,0 +1,57 @@
+import mimetypes
+
+
+MIMETYPE_OVERRIDES = {
+    # On Windows, mimetypes pulls this from the registry, which is
+    # wrong. Override it.
+    "application/javascript": ".js",
+}
+
+
+def decorate_mimetypes_init():
+    """
+    Decorate the mimetypes.init() method with our function that
+    afterwards adds any mimetype overrides that were saved.
+    """
+
+    original_init = mimetypes.init
+
+    def new_init(*args, **kwargs):
+        original_init(*args, **kwargs)
+        for key, value in MIMETYPE_OVERRIDES.items():
+            mimetypes.add_type(key, value)
+
+    mimetypes.init = new_init
+
+
+def add_mimetype_override(type, ext):
+    """
+    Add a mimetype both now and when mimetypes.init() is called.
+
+    :param type: mimetype
+    :type type: str
+    :param ext: file extension for which the mimetype applies
+    :type ext: str
+    """
+    # Add it to the overrides that are performed if init() is called
+    MIMETYPE_OVERRIDES[type] = ext
+
+    # Also override it right now
+    mimetypes.add_type(type, ext)
+
+
+def to_mime(file_path):
+    """
+    Return the mime type from a given path
+
+    :param file_path: Path to analyse
+    :type file_path: str
+
+    :return: Mime type
+    :rtype: str
+    """
+    return mimetypes.guess_type(file_path)[0]
+
+
+# Decorate the mimetypes.init() method
+decorate_mimetypes_init()

--- a/trame/assets/local.py
+++ b/trame/assets/local.py
@@ -1,21 +1,7 @@
 import base64
-import mimetypes
 from pathlib import Path
 
-mimetypes.init()
-
-
-def to_mime(file_path):
-    """
-    Return the mime type from a given path
-
-    :param file_path: Path to analyse
-    :type file_path: str
-
-    :return: Mime type
-    :rtype: str
-    """
-    return mimetypes.guess_type(file_path)[0]
+from trame.app.mimetypes import to_mime
 
 
 def to_txt(full_path):


### PR DESCRIPTION
On Windows, the mimetypes are obtained from the registry. However,
the mimetype for javascript files is broken. Add some code to ensure
that javascript files are identified correctly.

This also adds some infrastructure for adding extra mimetypes that
persist even if `mimetypes.init()` is called.

This fixes the issue that I was encountering on Windows.