### PR TITLE
Additional docker options

### DIFF
--- a/docker/scripts/build.sh
+++ b/docker/scripts/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Put any arguments into the `TRAME_BUILD` variable
+# This is so you can do things like `/opt/trame/build.sh no_www venv`, etc.
+export TRAME_BUILD="$*"
+export TRAME_BUILD_ONLY=1
+
+/opt/trame/entrypoint.sh

--- a/docker/scripts/server.sh
+++ b/docker/scripts/server.sh
@@ -1,34 +1,52 @@
 #!/usr/bin/env bash
 
-if [ ! -d $TRAME_VENV ]
-then
-  # We have access to PyYAML in the root python environment.
-  # Convert the apps.yml file to json and put it in the right place.
-  python /opt/trame/yaml_to_json.py /deploy/setup/apps.yml /opt/trame/apps.json
+LAUNCHER_OUTPUT_PATH=/deploy/server/launcher.json
+WWW_PATH=/deploy/server/www
+
+# Convert the apps.yml file to json and put it in the right place.
+# This needs PyYAML, which is in the root python environment, so
+# we must do this before activating the venv.
+python /opt/trame/yaml_to_json.py /deploy/setup/apps.yml /opt/trame/apps.json
+
+# venv
+# Build if it does not exist, or if "venv" is in `TRAME_BUILD`
+if [[ ! -d $TRAME_VENV || $TRAME_BUILD == *"venv"* ]]; then
+  # In case we are doing a force rebuild, make sure the directory is deleted
+  rm -rf $TRAME_VENV
 
   # Create (and activate) the venv
   . /opt/trame/create_venv.sh
 
   # Run the initialize script (if it exists)
-  if [ -f /deploy/setup/initialize.sh ]
-  then
+  if [[ -f /deploy/setup/initialize.sh ]]; then
     . /deploy/setup/initialize.sh
   fi
 
   # Install any specified requirements
   . /opt/trame/install_requirements.sh
+else
+  # Activate it if we skipped building it
+  . /opt/trame/activate_venv.sh
+fi
 
-  # Generate launcher.json and the www directory
+# launcher
+# Build if it does not exist, or if "launcher" is in `TRAME_BUILD`
+if [[ ! -f $LAUNCHER_OUTPUT_PATH || $TRAME_BUILD == *"launcher"* ]]; then
   python /opt/trame/generate_launcher_config.py
+fi
+
+# www
+# This must be done after activating the venv.
+# This directory should already exist.
+# Build if "no_www" is not in `TRAME_BUILD` and either it is empty or "www" is in `TRAME_BUILD`
+if [[ $TRAME_BUILD != *"no_www"* ]] && [[ -z "$(ls -A $WWW_PATH)" || $TRAME_BUILD == *"www"* ]]; then
+  # Generate launcher.json and the www directory
   python /opt/trame/generate_www.py
 
   # Merge any user-created www directories with the generated one
-  if [ -d /deploy/setup/www ]
-  then
+  if [[ -d /deploy/setup/www ]]; then
     cp -r /deploy/setup/www/* /deploy/server/www
   fi
-else
-  . /opt/trame/activate_venv.sh
 fi
 
 if [[ $TRAME_BUILD_ONLY == 1 ]]; then
@@ -42,7 +60,7 @@ fi
 # that the user doing the "docker run ..." has set up an external directory
 # containing a "server/launcher.json" filepath and mounts that path as
 # "/deploy".
-cp /deploy/server/launcher.json /opt/trame/config-template.json
+cp $LAUNCHER_OUTPUT_PATH /opt/trame/config-template.json
 
 # This performs replacements on the launcher-template.json copied into place
 # above, based on the presence of environment variables passed with "-e" to the

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -41,6 +41,10 @@
 #         -e EXTRA_PVPYTHON_ARGS="-dr,--mesa-swr" \
 #         ...
 #
+#
+# You may also replace `USE_HOST` via `TRAME_USE_HOST`.
+# If `TRAME_USE_HOST` contains `://`, then this will replace `ws://USE_HOST`
+# instead.
 
 ROOT_URL="ws://localhost"
 REPLACEMENT_ARGS=""
@@ -64,6 +68,17 @@ fi
 INPUT=$(<"${LAUNCHER_TEMPLATE_PATH}")
 OUTPUT="${INPUT//"SESSION_URL_ROOT"/$ROOT_URL}"
 OUTPUT="${OUTPUT//"EXTRA_PVPYTHON_ARGS"/$REPLACEMENT_ARGS}"
+
+if [[ -n $TRAME_USE_HOST ]]; then
+  REPLACEMENT_STRING="USE_HOST"
+  if [[ $TRAME_USE_HOST == *"://"* ]]; then
+    # If the string contains "://", then we are replacing the "ws://" at
+    # the beginning as well
+    REPLACEMENT_STRING="ws://$REPLACEMENT_STRING"
+  fi
+  OUTPUT="${OUTPUT//$REPLACEMENT_STRING/$TRAME_USE_HOST}"
+fi
+
 echo -e "$OUTPUT" > "${LAUNCHER_PATH}"
 
 # Run the pvw launcher in the foreground so this script doesn't end


### PR DESCRIPTION
The commit messages are pasted below:

# fix(docker): add additional build options

This allows the user to separate out building the venv, launcher, and www.

The default behavior is that all will build if they do not exist. If they do exist,
then they will not be built.

However, the user can now select some options via a `TRAME_BUILD` environment variable.
If this string contains (single or any combination of) "venv", "launcher", or "www",
then those respective parts will be re-built, even if they already exist.

Additionally, a "no_www" can be specified in the `TRAME_BUILD` environment variable,
which indicates to skip the `www` generation, even if it does not exist.

# fix(docker): add ability to replace USE_HOST
    
If a `TRAME_USE_HOST` environment variable is defined, then this will replace
`USE_HOST` in the final copy of the launcher json file.
    
If `TRAME_USE_HOST` contains `://`, then this will replace `ws://USE_HOST`
instead.