### PR TITLE
doc(website): Fix license reference

### DIFF
--- a/docs/content/index.pug
+++ b/docs/content/index.pug
@@ -219,7 +219,7 @@ ul#intro-feature-list(style="padding-top: 50px;")
         a(href="https://pypi.org/project/trame/").link Open Source
       p.intro-feature-desc
         b trame&nbsp;
-        | is an open source project licensed under BSD-3 which allows users to create
+        | is an open source project licensed under Apache License Version 2.0 which allows users to create
         | open source or commercial applications without any licensing worries.
 
   li.intro-feature-wrap(style="padding-top: 0;")


### PR DESCRIPTION
This commit fixes a regression introduced in 5f55d6a57 (docs(website): update content to match new api) updating the text describing the license to mention "Apache License Version 2.0" instead of "BSD-3".

The text now described the license effectively associated with the trame v2 project originally introduced in 0e44015c8 (trame a framework to write ubiquitous applications in Python).

For reference, trame v1 license  (originally introduced in e8fe5944b (chore: Getting started)) was BSD-3.
