### PR TITLE
docs(matplotlib): update examples to close the plots

### DIFF
--- a/examples/05_charts/Matplotlib/00_matplotlib-charts.py
+++ b/examples/05_charts/Matplotlib/00_matplotlib-charts.py
@@ -42,6 +42,7 @@ def figure_size():
 
 
 def FirstDemo():
+    plt.close("all")
     fig, ax = plt.subplots(**figure_size())
     np.random.seed(0)
     ax.plot(
@@ -63,6 +64,7 @@ def FirstDemo():
 
 
 def MultiLines():
+    plt.close("all")
     fig, ax = plt.subplots(**figure_size())
     x = np.linspace(0, 10, 1000)
     for offset in np.linspace(0, 3, 7):
@@ -78,6 +80,7 @@ def MultiLines():
 
 
 def DotsandPoints():
+    plt.close("all")
     fig, ax = plt.subplots(**figure_size())
     ax.plot(
         np.random.rand(20),
@@ -108,11 +111,11 @@ def MovingWindowAverage():
 
     kernel = np.ones(25) / 25.0
     x_smooth = np.convolve(x + dx, kernel, mode="same")
-
+    plt.close("all")
     fig, ax = plt.subplots(**figure_size())
     ax.plot(t, x + dx, linestyle="", marker="o", color="black", markersize=3, alpha=0.3)
     ax.plot(t, x_smooth, "-k", lw=3)
-    ax.plot(t, x, "--k", lw=3, color="blue")
+    ax.plot(t, x, "--", lw=3, color="blue")
 
     return fig
 
@@ -121,6 +124,7 @@ def MovingWindowAverage():
 
 
 def Subplots():
+    plt.close("all")
     fig = plt.figure(**figure_size())
     fig.subplots_adjust(hspace=0.3)
 


### PR DESCRIPTION
Two small fixes to the matplotlib example.

The matplotlib example 05_charts/Matplotlib/00_matplotlib-charts.py will replot the figure when you resize the window. When you resize it for a couple of seconds, you will get the message:
~/trame/examples/05_charts/Matplotlib/00_matplotlib-charts.py:45: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (matplotlib.pyplot.figure) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam figure.max_open_warning). Consider using matplotlib.pyplot.close(). fig, ax = plt.subplots(**figure_size())

I just placed a
plt.close('all')
before the fig,ax=plt.subplots() line and I did not get this message anymore.

00_matplotlib-charts.py:118: UserWarning: color is redundantly defined by the 'color' keyword argument and the fmt string "--k" (-> color='k'). The keyword argument will take precedence.
ax.plot(t, x, "--k", lw=3, color="blue")

I removed the "k" from the fmt string

see discussion on: https://github.com/Kitware/trame/discussions/349