### PR TITLE
Add Paraview Docker example

### DIFF
--- a/examples/07_paraview/Docker/Dockerfile
+++ b/examples/07_paraview/Docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM kitware/trame:py3.10-ubuntu22.04
+
+RUN install -d -o trame-user -g trame-user /deploy
+RUN apt update -y && apt install -y libosmesa6-dev
+
+ARG PV_URL='https://www.paraview.org/files/v5.12/ParaView-5.12.0-RC1-osmesa-MPI-Linux-Python3.10-x86_64.tar.gz'
+RUN mkdir -p /opt/paraview && cd /opt/paraview && wget -qO- $PV_URL | tar --strip-components=1 -xzv
+ENV TRAME_PARAVIEW=/opt/paraview
+
+COPY --chown=trame-user:trame-user . /deploy
+
+RUN /opt/trame/entrypoint.sh build

--- a/examples/07_paraview/Docker/SimpleCone.py
+++ b/examples/07_paraview/Docker/SimpleCone.py
@@ -1,0 +1,78 @@
+import paraview.web.venv  # Available in PV 5.10
+
+from trame.app import get_server
+from trame.widgets import vuetify, paraview
+from trame.ui.vuetify import SinglePageLayout
+
+from paraview import simple
+
+# -----------------------------------------------------------------------------
+# trame setup
+# -----------------------------------------------------------------------------
+
+server = get_server()
+server.client_type = "vue2"
+state, ctrl = server.state, server.controller
+
+# -----------------------------------------------------------------------------
+# ParaView code
+# -----------------------------------------------------------------------------
+
+DEFAULT_RESOLUTION = 6
+
+cone = simple.Cone()
+representation = simple.Show(cone)
+view = simple.Render()
+
+
+@state.change("resolution")
+def update_cone(resolution, **kwargs):
+    cone.Resolution = resolution
+    ctrl.view_update()
+
+
+def update_reset_resolution():
+    state.resolution = DEFAULT_RESOLUTION
+
+
+# -----------------------------------------------------------------------------
+# GUI
+# -----------------------------------------------------------------------------
+
+state.trame__title = "ParaView cone"
+
+with SinglePageLayout(server) as layout:
+    layout.icon.click = ctrl.view_reset_camera
+    layout.title.set_text("Cone Application")
+
+    with layout.toolbar:
+        vuetify.VSpacer()
+        vuetify.VSlider(
+            v_model=("resolution", DEFAULT_RESOLUTION),
+            min=3,
+            max=60,
+            step=1,
+            hide_details=True,
+            dense=True,
+            style="max-width: 300px",
+        )
+        vuetify.VDivider(vertical=True, classes="mx-2")
+        with vuetify.VBtn(icon=True, click=update_reset_resolution):
+            vuetify.VIcon("mdi-undo-variant")
+
+    with layout.content:
+        with vuetify.VContainer(
+            fluid=True,
+            classes="pa-0 fill-height",
+        ):
+            html_view = paraview.VtkRemoteView(view)
+            # html_view = paraview.VtkLocalView(view)
+            ctrl.view_update = html_view.update
+            ctrl.view_reset_camera = html_view.reset_camera
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    server.start()

--- a/examples/07_paraview/Docker/setup/apps.yml
+++ b/examples/07_paraview/Docker/setup/apps.yml
@@ -1,0 +1,11 @@
+trame:
+  cmd:
+    - /opt/paraview/bin/pvpython
+    - /deploy/SimpleCone.py
+    - --host
+    - ${host}
+    - --port
+    - ${port}
+    - --authKey
+    - ${secret}
+    - --server

--- a/examples/07_paraview/Docker/setup/requirements.txt
+++ b/examples/07_paraview/Docker/setup/requirements.txt
@@ -1,0 +1,3 @@
+trame
+trame-vtk
+trame-vuetify


### PR DESCRIPTION
New example allowing to run 07_paraview/SimpleCone from a headless docker container using X11 virtual frame buffer with Paraview 5.12.0-RC1 and Python 3.10

To run the example:
```
docker build -t paraview-trame .
docker run -ti -p 1234:8080 paraview-trame
```
SimpleCone should be accessible at localhost:1234