### PR TITLE
docs(community): fix image urls

### DIFF
--- a/docs/vitepress/examples/apps/community.md
+++ b/docs/vitepress/examples/apps/community.md
@@ -30,7 +30,7 @@ MRI Viewer is a web application **for analyzing and visualizing VTI files**. The
 
 <table>
   <tr>
-    <td><img src="https://github.com/karelvrabeckv/mri-viewer/blob/main/assets/aorta.png" alt="Aorta"></td>
-    <td><img src="https://github.com/karelvrabeckv/mri-viewer/blob/main/assets/brain.png" alt="Brain"></td>
+    <td><img src="https://raw.githubusercontent.com/karelvrabeckv/mri-viewer/main/assets/aorta.png" alt="Aorta"></td>
+    <td><img src="https://raw.githubusercontent.com/karelvrabeckv/mri-viewer/main/assets/brain.png" alt="Brain"></td>
   </tr>
 </table>


### PR DESCRIPTION
Images for MRI Viewer do not show up on [the website](https://kitware.github.io/trame/examples/apps/community.html).
This is the fix for it.
