### PR TITLE
Introducing Trame Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you need help don't hesitate [to reach out](https://www.kitware.com/trame/)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/trame)
 ![Conda - Downloads](https://pyviz.org/_static/cache/trame_conda_downloads_badge.svg)
 ![GitHub stars](https://img.shields.io/github/stars/kitware/trame)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Trame%20Guru-006BFF)](https://gurubase.io/g/trame)
 
 **trame** - a web framework that weaves together open source components into customized visual analytics easily.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Trame Guru](https://gurubase.io/g/trame) to Gurubase. Trame Guru uses the data from this repo and data from the [docs](https://kitware.github.io/trame/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Trame Guru", which highlights that Trame now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Trame Guru in Gurubase, just let me know that's totally fine.
