### PR TITLE
Build Python 3.11 image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,9 @@ jobs:
           - ubuntu: 22.04
             python: 3
             label: "3.10"
+          - ubuntu: 22.04
+            python: 3.11
+            label: 3.11
 
     # Start a local registry to which we will push trame-common, so that
     # docker buildx may access it in later steps.


### PR DESCRIPTION
Could the Trame image be built against Python 3.11 as well as 3.9 and 3.10?

My two main points are:
- Trame and vtk already support Python 3.11 (I was running 3.11 before I dockerised my application)
- It would allow users to benefit from [the performance boost of 3.11](https://docs.python.org/3/whatsnew/3.11.html#faster-cpython)
  - specifically `Interpreter startup is now 10-15% faster in Python 3.11.`, which would reduce the delay in spinning up the new Python process when a new `wslink` session is created


