### PR TITLE
Install `gosu` from `tianon/gosu` image instead of apt

### DIFF
--- a/docker/Dockerfile.common
+++ b/docker/Dockerfile.common
@@ -13,9 +13,10 @@ RUN apt-get update && \
       apache2 \
       apache2-dev \
       libapr1-dev \
-      apache2-utils \
-      gosu && \
+      apache2-utils && \
     rm -rf /var/lib/apt/lists/*
+
+COPY --from=tianon/gosu /gosu /usr/local/bin/
 
 # Set up needed permissions and users
 # - User groups:


### PR DESCRIPTION
When installing `gosu` using `apt`, [the latest available version is 1.14.1](https://packages.ubuntu.com/jammy/gosu).

When pointing Docker Scout at the image, it identifies this as bringing very many `critical` and `high` related vulnerabilities, related to the fact that it bundles golang 1.18.2.

This PR should address this by installing the latest `gosu` every time instead.