### PR TITLE
Build Docker container for Python 3.12, on top of Ubuntu 24.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,9 @@ jobs:
           - ubuntu: 22.04
             python: 3.11
             label: 3.11
+          - ubuntu: 24.04
+            python: 3.12
+            label: 3.12
 
     # Start a local registry to which we will push trame-common, so that
     # docker buildx may access it in later steps.


### PR DESCRIPTION
Allow the use of Python 3.12.
Switching to Ubuntu 24 because its the latest supported LTS, and there is no `python3.12` on older versions.