### PR TITLE
Revert "Build Docker container for Python 3.12, on top of Ubuntu 24.04"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,6 @@ jobs:
           - ubuntu: 22.04
             python: 3.11
             label: 3.11
-          - ubuntu: 24.04
-            python: 3.12
-            label: 3.12
 
     # Start a local registry to which we will push trame-common, so that
     # docker buildx may access it in later steps.


### PR DESCRIPTION
Reverts Kitware/trame#712

Some more changes needs to be made to support Ubuntu 24.04