### PR TITLE
Pep 420 style updates

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -56,13 +56,33 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Checkout trame-client fork for testing
+      uses: actions/checkout@v4
+      with:
+        repository: jcapriot/trame-client
+        ref: Pep420
+        path: local_trame_client
+    
+    - name: Install trame-client fork for testing
+      run: |
+        cd local_trame_client
+        cd vue2-app
+        npm ci
+        npm run build
+        cd ..
+        cd vue3-app
+        npm ci
+        npm run build
+        cd ..
+        pip install .
+
     - name: Install and Run Tests
       run: |
         pip install ".[dev]"
         pip install -r tests/requirements.txt
         # Run the tests with coverage so we get a coverage report too
         pip install coverage
-        coverage run --source . -m pytest .
+        coverage run --source . -m pytest . --ignore=local_trame_client
         # Print the coverage report
         coverage report -m
 

--- a/trame/__init__.py
+++ b/trame/__init__.py
@@ -1,1 +1,0 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/trame/assets/__init__.py
+++ b/trame/assets/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+

--- a/trame/modules/__init__.py
+++ b/trame/modules/__init__.py
@@ -1,1 +1,0 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/trame/tools/__init__.py
+++ b/trame/tools/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+

--- a/trame/ui/__init__.py
+++ b/trame/ui/__init__.py
@@ -1,1 +1,0 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/trame/widgets/__init__.py
+++ b/trame/widgets/__init__.py
@@ -1,1 +1,0 @@
-__path__ = __import__("pkgutil").extend_path(__path__, __name__)


### PR DESCRIPTION
Remove's legacy implicit namespace mechanisms.

Relies on `trame-client` providing the `__init__.py` for `trame`, `trame.modules`, `trame.ui`, and `trame.widgets`
