### PR TITLE
docs(tutorial): fix typos and improve clarity

### DIFF
--- a/docs/vitepress/guide/tutorial/application.md
+++ b/docs/vitepress/guide/tutorial/application.md
@@ -349,7 +349,7 @@ The ***trame*** widgets are easy to use. Here, we simply create the widget, defi
 
 ```python
 def pipeline_widget():
-    widgets.GitTree(
+    trame.GitTree(
         sources=(
             "pipeline",
             [

--- a/docs/vitepress/guide/tutorial/html.md
+++ b/docs/vitepress/guide/tutorial/html.md
@@ -145,7 +145,7 @@ with SinglePageLayout(server) as layout:
 ```bash
 python 03_html/app_cone.py --port 1234
 # or
-python 03_html/solution_buttons_a.py --port 1234
+python 03_html/solution_buttons.py --port 1234
 ```
 
 Your browser should open automatically to `http://localhost:1234/`
@@ -176,6 +176,7 @@ Let's add a `VSlider` for adjusting the resolution, a `VBtn` with `VIcon` to res
 
 ```python
 with SinglePageLayout(server) as layout:
+    # [...]
     with layout.toolbar:
         vuetify.VSpacer()
         vuetify.VSlider(

--- a/docs/vitepress/guide/tutorial/vtk.md
+++ b/docs/vitepress/guide/tutorial/vtk.md
@@ -195,6 +195,9 @@ with ... as layout:
 
 ```bash
 python ./01_vtk/app_cone.py --port 1234
+# or
+python ./01_vtk/solution_cone.py --port 1234
+
 ```
 
 Your browser should open automatically to `http://localhost:1234/`
@@ -211,7 +214,7 @@ Now you can take most of the code examples at [VTK Examples](https://kitware.git
 
 [![Carotid Flow VTK Example](/assets/images/tutorial/carotid.jpg)](https://kitware.github.io/vtk-examples/site/Python/VisualizationAlgorithms/CarotidFlowGlyphs/)
 
-We are going to implement [CarotidFlowGlyphs](https://kitware.github.io/vtk-examples/site/Python/VisualizationAlgorithms/CarotidFlowGlyphs/) by editing the file in `01_vtk/app_flow.py.py` which start from our cone rendering example solution.
+We are going to implement [CarotidFlowGlyphs](https://kitware.github.io/vtk-examples/site/Python/VisualizationAlgorithms/CarotidFlowGlyphs/) by editing the file in `01_vtk/app_flow.py` which start from our cone rendering example solution.
 
 <div class="print-break"></div>
 
@@ -363,6 +366,8 @@ Our pipelines are the same pipelines used in [VTK Examples](https://kitware.gith
 
 ```bash
 python ./01_vtk/app_flow.py --port 1234
+# or
+python ./01_vtk/solution_flow.py --port 1234
 ```
 
 Your browser should open automatically to `http://localhost:1234/`


### PR DESCRIPTION
Fixed typos and improved clarity on the VTK, HTML and Application pages of the tutorial