### PR TITLE
Fix examples2 fix build doc fail

### DIFF
--- a/docs/vitepress/examples/core/docker.md
+++ b/docs/vitepress/examples/core/docker.md
@@ -7,8 +7,8 @@ For instance you could deploy the following on a CapRover instance by just runni
 [![Simple deployment over https](/assets/images/deployment/cone-caprover.png)](https://github.com/Kitware/trame-app-cone)
 
 ::: code-group
-<<< @/../../examples/deploy/docker/Dockerfile
-<<< @/../../examples/deploy/docker/captain-definition
+<<< @/../../examples/deploy/docker/VtkRendering/Dockerfile
+<<< @/../../examples/deploy/docker/VtkRendering/captain-definition
 <<< @/../../examples/deploy/docker/VtkRendering/app.py
 <<< @/../../examples/deploy/docker/VtkRendering/setup/apps.yml [./setup/apps.yaml]
 <<< @/../../examples/deploy/docker/VtkRendering/setup/requirements.txt [./setup/requirements.txt]


### PR DESCRIPTION
Last PR https://github.com/Kitware/trame/pull/876 that was merged failed to build the doc: https://github.com/Kitware/trame/actions/runs/24511784824/job/71644607253

It was a code snippet path error (my mistake), I correct it in this PR

I tested locally
```
ulysse-durand@ulyssedurand:~/git/trame/docs/vitepress$ npm ci

added 129 packages, and audited 130 packages in 1s

38 packages are looking for funding
  run `npm fund` for details

4 vulnerabilities (3 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
ulysse-durand@ulyssedurand:~/git/trame/docs/vitepress$ npm run docs:build

> docs:build
> vitepress build


  vitepress v1.6.4

⠸ building client + server bundles...
The language 'ipynb' is not loaded, falling back to 'txt' for syntax highlighting.

The language 'ipynb' is not loaded, falling back to 'txt' for syntax highlighting. (x2)
⠦ building client + server bundles...
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
⠹ building client + server bundles...
The language 'ipynb' is not loaded, falling back to 'txt' for syntax highlighting.
✓ building client + server bundles...
✓ rendering pages...
build complete in 10.79s.
```