### PR TITLE
docs(examples): make the paraview with docker example work

### DIFF
--- a/examples/07_paraview/Docker/Dockerfile
+++ b/examples/07_paraview/Docker/Dockerfile
@@ -7,6 +7,12 @@ RUN install -d -o trame-user -g trame-user /deploy
 ARG PV_URL='https://www.paraview.org/files/v6.1/ParaView-6.1.0-MPI-Linux-Python3.12-x86_64.tar.gz'
 RUN mkdir -p /opt/paraview && cd /opt/paraview && wget -qO- $PV_URL | tar --strip-components=1 -xzv
 ENV TRAME_PARAVIEW=/opt/paraview
+ENV VTK_DEFAULT_OPENGL_WINDOW=vtkEGLRenderWindow
+
+RUN apt-get update && apt-get install -y \
+    libpciaccess-dev \
+    libxcursor-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --chown=trame-user:trame-user . /deploy
 

--- a/examples/07_paraview/Docker/SimpleCone.py
+++ b/examples/07_paraview/Docker/SimpleCone.py
@@ -1,15 +1,9 @@
 from paraview import simple
 
-from trame.app import get_server
-from trame.ui.vuetify import SinglePageLayout
-from trame.widgets import paraview, vuetify
-
-# -----------------------------------------------------------------------------
-# trame setup
-# -----------------------------------------------------------------------------
-
-server = get_server(client_type="vue2")
-state, ctrl = server.state, server.controller
+from trame.app import TrameApp
+from trame.ui.vuetify3 import SinglePageLayout
+from trame.widgets import vuetify3 as v3, paraview
+from trame.decorators import change
 
 # -----------------------------------------------------------------------------
 # ParaView code
@@ -21,55 +15,70 @@ cone = simple.Cone()
 representation = simple.Show(cone)
 view = simple.Render()
 
-
-@state.change("resolution")
-def update_cone(resolution, **kwargs):
-    cone.Resolution = resolution
-    ctrl.view_update()
-
-
-def update_reset_resolution():
-    state.resolution = DEFAULT_RESOLUTION
-
-
 # -----------------------------------------------------------------------------
-# GUI
+# trame setup
 # -----------------------------------------------------------------------------
 
-state.trame__title = "ParaView cone"
 
-with SinglePageLayout(server) as layout:
-    layout.icon.click = ctrl.view_reset_camera
-    layout.title.set_text("Cone Application")
+class SimpleCone(TrameApp):
+    def __init__(self, server=None):
+        super().__init__(server)
+        self._build_ui()
 
-    with layout.toolbar:
-        vuetify.VSpacer()
-        vuetify.VSlider(
-            v_model=("resolution", DEFAULT_RESOLUTION),
-            min=3,
-            max=60,
-            step=1,
-            hide_details=True,
-            dense=True,
-            style="max-width: 300px",
-        )
-        vuetify.VDivider(vertical=True, classes="mx-2")
-        with vuetify.VBtn(icon=True, click=update_reset_resolution):
-            vuetify.VIcon("mdi-undo-variant")
+    @change("resolution")
+    def update_cone(self, resolution, **kwargs):
+        cone.Resolution = resolution
+        self.ctrl.view_update()
 
-    with layout.content:
-        with vuetify.VContainer(
-            fluid=True,
-            classes="pa-0 fill-height",
-        ):
-            html_view = paraview.VtkRemoteView(view)
-            # html_view = paraview.VtkLocalView(view)
-            ctrl.view_update = html_view.update
-            ctrl.view_reset_camera = html_view.reset_camera
+    def update_reset_resolution(self):
+        self.state.resolution = DEFAULT_RESOLUTION
+
+    # -----------------------------------------------------------------------------
+    # GUI
+    # -----------------------------------------------------------------------------
+
+    def _build_ui(self):
+        self.state.trame__title = "ParaView cone"
+
+        with SinglePageLayout(self.server) as self.ui:
+            self.ui.icon.click = self.ctrl.view_reset_camera
+            self.ui.title.set_text("Cone Application")
+
+            with self.ui.toolbar:
+                v3.VSpacer()
+                v3.VSlider(
+                    v_model=("resolution", DEFAULT_RESOLUTION),
+                    min=3,
+                    max=60,
+                    step=1,
+                    hide_details=True,
+                    dense=True,
+                    style="max-width: 300px",
+                )
+                v3.VDivider(vertical=True, classes="mx-2")
+                with v3.VBtn(icon=True, click=self.update_reset_resolution):
+                    v3.VIcon("mdi-undo-variant")
+
+            with self.ui.content:
+                with v3.VContainer(
+                    fluid=True,
+                    classes="pa-0 fill-height",
+                ):
+                    html_view = paraview.VtkRemoteView(view)
+                    # html_view = paraview.VtkLocalView(view)
+                    self.ctrl.view_update = html_view.update
+                    self.ctrl.view_reset_camera = html_view.reset_camera
+
 
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
+
+def main():
+    app = SimpleCone()
+    app.server.start()
+
+
 if __name__ == "__main__":
-    server.start()
+    main()

--- a/examples/07_paraview/Docker/SimpleCone.py
+++ b/examples/07_paraview/Docker/SimpleCone.py
@@ -11,10 +11,6 @@ from trame.decorators import change
 
 DEFAULT_RESOLUTION = 6
 
-cone = simple.Cone()
-representation = simple.Show(cone)
-view = simple.Render()
-
 # -----------------------------------------------------------------------------
 # trame setup
 # -----------------------------------------------------------------------------
@@ -23,11 +19,16 @@ view = simple.Render()
 class SimpleCone(TrameApp):
     def __init__(self, server=None):
         super().__init__(server)
+
+        self.cone = simple.Cone()
+        self.representation = simple.Show(self.cone)
+        self.view = simple.Render()
+
         self._build_ui()
 
     @change("resolution")
-    def update_cone(self, resolution, **kwargs):
-        cone.Resolution = resolution
+    def update_cone(self, resolution, **_kwargs):
+        self.cone.Resolution = resolution
         self.ctrl.view_update()
 
     def update_reset_resolution(self):
@@ -53,6 +54,7 @@ class SimpleCone(TrameApp):
                     step=1,
                     hide_details=True,
                     dense=True,
+                    density="compact",
                     style="max-width: 300px",
                 )
                 v3.VDivider(vertical=True, classes="mx-2")
@@ -64,7 +66,7 @@ class SimpleCone(TrameApp):
                     fluid=True,
                     classes="pa-0 fill-height",
                 ):
-                    html_view = paraview.VtkRemoteView(view)
+                    html_view = paraview.VtkRemoteView(self.view, interactive_ratio=1)
                     # html_view = paraview.VtkLocalView(view)
                     self.ctrl.view_update = html_view.update
                     self.ctrl.view_reset_camera = html_view.reset_camera

--- a/examples/07_paraview/Docker/setup/apps.yml
+++ b/examples/07_paraview/Docker/setup/apps.yml
@@ -1,6 +1,8 @@
 trame:
   cmd:
     - /opt/paraview/bin/pvpython
+    - --venv
+    - /deploy/server/venv
     - /deploy/SimpleCone.py
     - --host
     - ${host}


### PR DESCRIPTION
Fix the Paraview with Docker example

- Put --venv argument to `pvpython`
- Change `Dockerfile` to select working openGL renderer
- Change `Dockerfile` to install libpciaccess and libxcursor
- Make `SimpleCone.py` use vuetify3 and TrameApp

fix #875 
