### PR TITLE
chore: add libraries to RTD

### DIFF
--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -39,3 +39,6 @@ trame-formkit
 trame-quasar
 trame-datagrid
 trame-image-tools
+trame-tauri
+trame-gwc
+trame-dockview


### PR DESCRIPTION
Add trame-tauri, trame-gwc and trame-dockview to RTD

Related to #842