### PR TITLE
docs(catalogs): change non-kitware repo emoji and action on click topic

### DIFF
--- a/docs/vitepress/.vitepress/theme/RepoList.vue
+++ b/docs/vitepress/.vitepress/theme/RepoList.vue
@@ -178,7 +178,7 @@ function toggleSortDir() {
         </td>
         <td>
           <h4 class="repo-title">
-            <span v-if="!r.trusted" title="Non Kitware-owned">⚠️</span>
+            <span v-if="!r.trusted" title="Non Kitware-owned">🧑‍🤝‍🧑</span>
             <span v-if="r.createdWithinLastYear" title="Created within the last year">🆕</span>
             {{ r.name }}
           </h4>
@@ -186,11 +186,12 @@ function toggleSortDir() {
         </td>
         <td>
           <div v-for="tag in getDisplayableTagsForRepo(r.topics)" :key="tag.key">
-            <a :href="tag.key === '...' ? '' : 'https://github.com/topics/' + tag.githubTopic">
-              <span :class="['pill', 'topic', activeTopics.has(tag.key) && 'active']">
-                  {{ tag.label }}
-              </span>
-            </a>        
+            <span 
+              :class="['pill', 'topic', activeTopics.has(tag.key) && 'active']"
+              @click="toggleTopic(tag.key)"
+            >
+                {{ tag.label }}
+            </span>
           </div>
         </td>
       </tr>

--- a/docs/vitepress/guide/intro/applications.md
+++ b/docs/vitepress/guide/intro/applications.md
@@ -12,7 +12,4 @@ const topics = {
 
 # Application catalog
 
-⚠️: Non Kitware-owned repository
-<br/>
-
 <RepoList filter-topic="trame-app" :displayable-topics="topics" />

--- a/docs/vitepress/guide/intro/widgets.md
+++ b/docs/vitepress/guide/intro/widgets.md
@@ -11,7 +11,4 @@ const topics = {
 
 # Widget catalog
 
-⚠️: Non Kitware-owned repository
-<br/>
-
 <RepoList filter-topic="trame-widget" :displayable-topics="topics" />


### PR DESCRIPTION
The text on top of the page for the emoji meaning is removed and the emoji is now less worrying: 🧑‍🤝‍🧑.
Now clicking a topic will toggle its filtering instead of redirecting to the github topic page.

